### PR TITLE
feat: Add dwarf register list for aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jeandleAssembler_aarch64.cpp
@@ -155,8 +155,9 @@ void JeandleAssembler::patch_call_vm(int inst_offset, address target) {
 }
 
 int JeandleAssembler::fixup_call_inst_offset(int offset) {
-  assert(offset >= 0, "invalid offset")
-  return offset;
+  assert(offset >= 0, "invalid offset");
+  // point to the end of call instruction
+  return offset + NativeInstruction::instruction_size;
 }
 
 bool JeandleAssembler::is_oop_reloc_kind(LinkKind kind) {

--- a/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/jeandleRegister_aarch64.hpp
@@ -36,18 +36,20 @@ public:
   }
 
   static const bool is_stack_pointer(Register reg) {
-    Unimplemented();
-    return false;
+    return reg == sp;
   }
 
   static const Register decode_dwarf_register(int dwarf_encoding) {
-    Unimplemented();
-    return noreg;
+    assert(dwarf_encoding >=0 && dwarf_encoding < Register::number_of_registers, "invalid dwarf register number");
+    return _dwarf_registers[dwarf_encoding];
   }
 
 private:
   static constexpr const Register _dwarf_registers[Register::number_of_registers] = {
-    /* Unimplemented */
+    r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10,
+    r11, r12, r13, r14, r15, r16, r17, r18_tls, r19, r20,
+    r21, r22, r23, r24, r25, r26, r27, r28, r29, r30,
+    sp
   };
 };
 

--- a/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
+++ b/src/hotspot/share/jeandle/jeandleCompiledCode.cpp
@@ -30,6 +30,7 @@
 #include "utilities/debug.hpp"
 #include "asm/macroAssembler.hpp"
 #include "ci/ciEnv.hpp"
+#include "code/vmreg.inline.hpp"
 
 namespace {
 


### PR DESCRIPTION
## Related issue(s):

issue #

## What this PR does / why we need it:

Add dwarf register definition for aarch64.

Testing:
 - [x] slowdebug/release build and tier1_compiler_jeandle